### PR TITLE
fix for code scanning alert no. 6: Information exposure through an exception

### DIFF
--- a/app/services/upload_service_account.py
+++ b/app/services/upload_service_account.py
@@ -19,4 +19,5 @@ def upload_service_account():
         return jsonify({"message": "Service account uploaded successfully."}), 200
  
     except Exception as e:
-        return jsonify({"error": str(e)}), 400
+        app.logger.error("Exception occurred", exc_info=True)
+        return jsonify({"error": "An internal error has occurred."}), 500


### PR DESCRIPTION
Potential fix for [https://github.com/the-data-omni/data_omni_api/security/code-scanning/6](https://github.com/the-data-omni/data_omni_api/security/code-scanning/6)

To fix the problem, we should avoid sending the exception message directly to the user. Instead, we should log the detailed error message on the server and return a generic error message to the user. This ensures that sensitive information is not exposed while still allowing developers to debug issues using the server logs.

- Modify the exception handling block to log the exception message and return a generic error message.
- Ensure that the logging mechanism is properly set up to capture the detailed error information.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
